### PR TITLE
Update Java keywords

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -81,7 +81,7 @@ return       self         super        then         true
 undef        unless       until        when         while
 yield
 
-### Java (50 keywords)
+### Java (51 keywords)
 
 abstract     continue     for          new          switch
 assert       default      goto         package      synchronized

--- a/README.txt
+++ b/README.txt
@@ -19,7 +19,7 @@ A list and count of keywords in programming languages.
 │       ...... ...... ...... ...... ...... ...... ...... ...... ...... ...... │
 │...... ...... ...... ...... ...... ...... ...... ...... ...... ...... ...... │
 │...... ...... ...... ...... ...... ...... ...... ...... ...... ...... ...... │
-│..25.. ..26.. ..32.. ..33.. ..36.. ..50.. ..52.. ..54.. ..89.. .100.. .109.. │
+│..25.. ..26.. ..32.. ..33.. ..36.. ..51.. ..52.. ..54.. ..89.. .100.. .109.. │
 │Go     Erlang C      Python Ruby   Java   Rust   Dart   Swift  C#     C++    │
 └─────────────────────────────────────────────────────────────────────────────┘
 
@@ -93,6 +93,7 @@ catch        extends      int          short        try
 char         final        interface    static       void
 class        finally      long         strictfp     volatile
 const        float        native       super        while
+_ (underscore)
 
 ### Rust (52 keywords)
 

--- a/chart.go
+++ b/chart.go
@@ -3,7 +3,7 @@ package main
 import "github.com/gizak/termui"
 
 var labels = []string{"Go", "Erlang", "C", "Python", "Ruby", "Java", "Rust", "Dart", "Swift", "C#", "C++"}
-var values = []int{25, 26, 32, 33, 36, 50, 52, 54, 89, 100, 109}
+var values = []int{25, 26, 32, 33, 36, 51, 52, 54, 89, 100, 109}
 
 func main() {
 	if err := termui.Init(); err != nil {


### PR DESCRIPTION
Hey,

since *Java 9* the underscore is an official keyword: https://docs.oracle.com/javase/specs/jls/se9/html/jls-3.html#jls-3.9

Also in *Java 10*: https://docs.oracle.com/javase/specs/jls/se10/html/jls-3.html#jls-3.9

Regards